### PR TITLE
fix(android): prevent crash in getHasGms() when play-services-base is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1]
+
+### Fixed
+
+- **iOS**: `getIpAddress()` and `getIpAddressSync()` now consistently return IPv4 addresses when available ([#39](https://github.com/l2hyunwoo/react-native-nitro-device-info/issues/39))
+  - Previously, the functions could return IPv6 addresses inconsistently due to network interface enumeration order
+  - IPv4 addresses are now prioritized, with IPv6 used only as a fallback when no IPv4 is available
+
+- **Android**: `getHasGms()` no longer crashes when `play-services-base` dependency is not included ([#40](https://github.com/l2hyunwoo/react-native-nitro-device-info/issues/40))
+  - Previously, calling `getHasGms()` without the GMS dependency would throw a JNI exception (`NoClassDefFoundError`)
+  - The function now catches `NoClassDefFoundError` explicitly (not `Throwable`) to avoid masking serious JVM errors
+  - This allows apps distributed on non-GMS stores (Amazon, Huawei AppGallery) to safely use this API
+
 ## [1.4.0] - 2025-12-01
 
 ### Added
@@ -161,6 +174,7 @@ const charging = DeviceInfoModule.getIsBatteryCharging();
 All getter functions have been converted to readonly properties for cleaner, more intuitive access ([#20](https://github.com/l2hyunwoo/react-native-nitro-device-info/pull/20)):
 
 **Before (v1.1.x)**:
+
 ```typescript
 const brand = DeviceInfoModule.getBrand();
 const model = DeviceInfoModule.getModel();
@@ -168,6 +182,7 @@ const isTablet = DeviceInfoModule.isTablet();
 ```
 
 **After (v1.2.0)**:
+
 ```typescript
 const brand = DeviceInfoModule.brand;
 const model = DeviceInfoModule.model;

--- a/android/src/main/java/com/margelo/nitro/nitrodeviceinfo/DeviceInfo.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrodeviceinfo/DeviceInfo.kt
@@ -488,18 +488,21 @@ class DeviceInfo : HybridDeviceInfoSpec() {
 
     /**
      * Check if Google Mobile Services (GMS) is available
-     * Catches Throwable (not just Exception) to handle NoClassDefFoundError
-     * when play-services-base dependency is not included in the app.
+     * Catches both Exception and NoClassDefFoundError to handle cases where
+     * play-services-base dependency is not included in the app.
      */
     override fun getHasGms(): Boolean {
         return try {
             val result =
                 GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
             result == ConnectionResult.SUCCESS
-        } catch (e: Throwable) {
-            // Using Throwable to catch NoClassDefFoundError when GMS library is not included
+        } catch (e: Exception) {
+            Log.d(NAME, "GMS not available", e)
+            false
+        } catch (e: NoClassDefFoundError) {
+            // NoClassDefFoundError is thrown when GMS library is not included
             // This is expected in apps distributed on non-GMS stores (Amazon, Huawei AppGallery)
-            Log.d(NAME, "GMS not available or GMS library not found", e)
+            Log.d(NAME, "GMS library not found", e)
             false
         }
     }


### PR DESCRIPTION
## Issue

close #40 

## Summary

Fixes `getHasGms()` to gracefully return `false` instead of crashing when `play-services-base` dependency is not included in the app.

## Problem

When an Android app does not include the `play-services-base` dependency, calling `getHasGms()` would crash with a JNI exception. This occurred because:

  1. `GoogleApiAvailability.getInstance()` throws `NoClassDefFoundError` when the class cannot be loaded
  2. `NoClassDefFoundError` extends `Error`, not `Exception`
  3. The existing `catch (e: Exception)` block did not catch `Error` types

```
  Throwable
  ├── Exception  ← catch (e: Exception) catches this
  └── Error
      └── LinkageError
          └── NoClassDefFoundError  ← This was NOT caught
```

## Solution

Changed error handling from `catch (e: Exception)` to `catch (e: Throwable)` to catch all error types including `NoClassDefFoundError`.

```kotlin
  // Before
  catch (e: Exception) {
      Log.w(NAME, "GMS not available or GMS library not found", e)
      false
  }

  // After
  catch (e: Throwable) {
      Log.d(NAME, "GMS not available or GMS library not found", e)
      false
  }
```

  Also changed log level from Log.w (warning) to Log.d (debug) since missing GMS is an expected scenario for apps distributed on non-GMS stores.