### PR TITLE
fix(ios): prioritize IPv4 over IPv6 in getIpAddress()

### DIFF
--- a/ios/DeviceInfo.swift
+++ b/ios/DeviceInfo.swift
@@ -413,8 +413,8 @@ class DeviceInfo: HybridDeviceInfoSpec {
         freeifaddrs(ifaddr)
       }
 
-      // Return IPv4 if available, otherwise IPv6, otherwise empty string
-      return ipv4Address ?? ipv6Address ?? ""
+      // Return IPv4 if available, otherwise IPv6, otherwise "unknown"
+      return ipv4Address ?? ipv6Address ?? "unknown"
     }
   }
 
@@ -864,8 +864,8 @@ class DeviceInfo: HybridDeviceInfoSpec {
     var ipv6Address: String?
     var ifaddr: UnsafeMutablePointer<ifaddrs>?
 
-    guard getifaddrs(&ifaddr) == 0 else { return "" }
-    guard let firstAddr = ifaddr else { return "" }
+    guard getifaddrs(&ifaddr) == 0 else { return "unknown" }
+    guard let firstAddr = ifaddr else { return "unknown" }
 
     defer { freeifaddrs(ifaddr) }
 
@@ -903,8 +903,8 @@ class DeviceInfo: HybridDeviceInfoSpec {
       }
     }
 
-    // Return IPv4 if available, otherwise IPv6, otherwise empty string
-    return ipv4Address ?? ipv6Address ?? ""
+    // Return IPv4 if available, otherwise IPv6, otherwise "unknown"
+    return ipv4Address ?? ipv6Address ?? "unknown"
   }
 
   /// Get MAC address (hardcoded on iOS 7+ due to privacy restrictions)


### PR DESCRIPTION
resolves #39

## Summary

Fixes `getIpAddress()` and `getIpAddressSync()` to consistently return IPv4 addresses when available on iOS.

## Problem

The iOS implementation of `getIpAddress()` was iterating through network interfaces and overwriting the `address` variable with each discovered address. When IPv6 interfaces appeared after IPv4 in the enumeration order, the function would return an IPv6 address instead of IPv4.

```swift
  // Before: Last address wins (could be IPv6)
  if addrFamily == UInt8(AF_INET) || addrFamily == UInt8(AF_INET6) {
      address = String(cString: hostname)  // Overwrites on each iteration
  }
```

## Solution

Refactored both getIpAddress() and queryIpAddressInternal() to:
1. Store IPv4 and IPv6 addresses separately
2. Prioritize IPv4 addresses when available
3. Use IPv6 only as a fallback when no IPv4 address exists

```swift
  // After: IPv4 prioritized, IPv6 as fallback
  if addrFamily == UInt8(AF_INET) {
      ipv4Address = address
  } else if addrFamily == UInt8(AF_INET6) && ipv6Address == nil {
      ipv6Address = address
  }
```

## Screenshot

<img width="370" height="277" alt="스크린샷 2025-12-02 오전 8 51 35" src="https://github.com/user-attachments/assets/334bf08c-0ca6-4f0a-ada1-d94d3561501c" />
