### PR TITLE
fix(mcp-server): add .npmrc to fix npm publish workspace protocol error

### DIFF
--- a/packages/mcp-server/.npmrc
+++ b/packages/mcp-server/.npmrc
@@ -1,0 +1,1 @@
+workspaces=false


### PR DESCRIPTION
## Summary
- Fix `EUNSUPPORTEDPROTOCOL` error during npm publish by adding `.npmrc` with `workspaces=false`

## Problem
npm publish failed with:
```
  npm error code EUNSUPPORTEDPROTOCOL
  npm error Unsupported URL Type "workspace:": workspace:*
```

This occurred because npm scanned the monorepo and encountered `workspace:*` protocol in `example/benchmark/package.json`, which npm doesn't understand (it's a yarn/pnpm workspace feature).

## Solution
- Add `packages/mcp-server/.npmrc` with `workspaces=false` to disable npm's workspace scanning during publish. 
  - This allows `npm publish --provenance` to work correctly without affecting yarn-based development workflow.