### PR TITLE
fix: add Folly configuration for RN 0.77-0.79 with static frameworks

### DIFF
--- a/packages/react-native-nitro-device-info/NitroDeviceInfo.podspec
+++ b/packages/react-native-nitro-device-info/NitroDeviceInfo.podspec
@@ -20,6 +20,13 @@ Pod::Spec.new do |s|
     "cpp/**/*.{hpp,cpp}",
   ]
 
+  # Fix for RN 0.77-0.79 with static frameworks (from https://github.com/mrousavy/nitro/pull/825)
+  s.pod_target_xcconfig = {
+    "HEADER_SEARCH_PATHS" => "${PODS_ROOT}/RCT-Folly",
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES",
+    "OTHER_CPLUSPLUSFLAGS" => "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
+  }
+
   s.dependency 'React-Core'
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'


### PR DESCRIPTION
## Summary

This fixes build failures when using `use_frameworks! :linkage => :static` (often required for Firebase integration) on React Native 0.77-0.79.

The build error encountered:
```
'folly/dynamic.h' file not found
```

## Changes

Adds `pod_target_xcconfig` with:
- Header search paths for RCT-Folly
- Preprocessor definitions for `FOLLY_NO_CONFIG` and `FOLLY_CFG_NO_COROUTINES`
- C++ compiler flags for Folly mobile configuration

## Reference

- https://github.com/mrousavy/nitro/pull/825
- https://github.com/oblador/react-native-nitro-haptics/pull/15 (same fix for react-native-nitro-haptics)