### PR TITLE
feat(iOS): recognize iPhone 17e in lookup table

### DIFF
--- a/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
+++ b/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
@@ -214,6 +214,7 @@ class DeviceInfo: HybridDeviceInfoSpec {
     "iPhone18,2": "iPhone 17 Pro Max",
     "iPhone18,3": "iPhone 17",
     "iPhone18,4": "iPhone Air",
+    "iPhone18,5": "iPhone 17e",
 
     // MARK: iPod
     "iPod1,1": "iPod Touch",


### PR DESCRIPTION
This makes sure marketing name of newly released iPhone 17e is known for `model` property when being looked up by the devideId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new iPhone 17e device model detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->