### PR TITLE
fix: widen Nitro modules peer dependency range

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -31,7 +31,7 @@ yarn add react-native-nitro-device-info react-native-nitro-modules
 pnpm add react-native-nitro-device-info react-native-nitro-modules
 ```
 
-> **참고:** `react-native-nitro-modules` 버전 ^0.31.0 이상이 필요합니다.
+> **참고:** `react-native-nitro-modules` 버전 >=0.35.0 <1.0.0이 필요합니다.
 
 ### iOS 설정
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add react-native-nitro-device-info react-native-nitro-modules
 pnpm add react-native-nitro-device-info react-native-nitro-modules
 ```
 
-> **Note**: `react-native-nitro-modules` ^0.31.0 is required as a peer dependency.
+> **Note**: `react-native-nitro-modules` >=0.35.0 <1.0.0 is required as a peer dependency.
 
 ### iOS Setup
 

--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -26,7 +26,7 @@ yarn add react-native-nitro-device-info react-native-nitro-modules
 pnpm add react-native-nitro-device-info react-native-nitro-modules
 ```
 
-> **Important**: `react-native-nitro-modules` ^0.31.0 is required as a peer dependency for JSI bindings.
+> **Important**: `react-native-nitro-modules` >=0.35.0 <1.0.0 is required as a peer dependency for JSI bindings.
 
 ## Platform Setup
 

--- a/packages/react-native-nitro-device-info/package.json
+++ b/packages/react-native-nitro-device-info/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "0.35.0"
+    "react-native-nitro-modules": ">=0.35.0 <1.0.0"
   },
   "devDependencies": {
     "del-cli": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10853,7 +10853,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: 0.35.0
+    react-native-nitro-modules: ">=0.35.0 <1.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- widen `react-native-nitro-modules` peer dependency from exact `0.35.0` to `>=0.35.0 <1.0.0`
- update README, Korean README, and getting-started docs to show the same supported range

## Rationale
`react-native-nitro-modules` is backwards compatible across minor releases, so consumers should not be forced to install exactly `0.35.0` when newer compatible `0.x` releases are available.

Supporting context from mrousavy / Margelo:
> react-native-nitro-modules is backwards compatible. So if your lib is built with Nitro 0.28.0, and the user installs 0.29.0, then it will still work.

<img width="994" height="825" alt="image" src="https://github.com/user-attachments/assets/64a6d556-cd3a-4693-b3a4-7e956bbbbfff" />


## Testing
- Not run; metadata and documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files (English and Korean versions) and getting-started guide with revised peer dependency specifications for installation guidance.

* **Chores**
  * Modified peer dependency version range configuration to support broader compatibility with newer releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/l2hyunwoo/react-native-nitro-device-info/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->