### PR TITLE
test: fix root jest by delegating to per-workspace projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Monorepo for `react-native-nitro-device-info` (v1.5.1), a high-performance React
 | `package.json` | Monorepo root with workspace definitions and shared scripts |
 | `turbo.json` | Turborepo configuration for build caching and task orchestration |
 | `.nvmrc` | Node.js version (20) |
-| `.yarnrc.yml` | Yarn 3.6.1 configuration with PnP mode |
+| `.yarnrc.yml` | Yarn 3.6.1 configuration (`nodeLinker: node-modules`, not PnP) |
 | `tsconfig.json` | Root TypeScript configuration |
 | `README.md` | Main project documentation |
 | `CONTRIBUTING.md` | Development workflow and guidelines |
@@ -56,6 +56,27 @@ Monorepo for `react-native-nitro-device-info` (v1.5.1), a high-performance React
 | `.github/` | CI/CD workflows (see `.github/AGENTS.md`) |
 
 ## For AI Agents
+
+### Agent Safety & Tooling Pitfalls (read first)
+
+These are non-obvious traps that have bitten automated runs. Follow them before touching the repo.
+
+**Package manager — Yarn 3.6.1 (Berry), `nodeLinker: node-modules`.** Not PnP. Deps are hoisted into `node_modules`, but `ts-jest` (mcp-server) and `react-native-harness` (showcase/integrity-demo) live in their *workspace* `node_modules`, not the root. Lockfile-only refresh: `yarn install --mode update-lockfile`.
+
+**Worktree isolation when the main checkout is dirty.** If the working tree has unrelated in-progress work (e.g. a feature branch with uncommitted changes), do NOT stash-juggle it to do an independent task. Cut a worktree off the base branch instead so the dirty checkout is never disturbed:
+```bash
+git worktree add ../<repo>-wt-<topic> <base-branch>   # e.g. main
+# worktrees have NO node_modules — run `yarn install` inside if you need to lint/test/build there
+git -C ../<repo>-wt-<topic> ... ; git push
+git worktree remove ../<repo>-wt-<topic>              # clean up when done
+```
+A fresh worktree needs its own `yarn install` (node-modules linker) before `yarn lint`/`test`/`typecheck` run there.
+
+**Linting: `yarn lint` (oxlint) is the gate — `yarn lint:eslint` is pre-existing broken.** The real lint script is `oxlint .`. The auxiliary `yarn lint:eslint` uses `@react-native` eslint config (a Babel parser) which throws `No Babel config file detected` on every root-level `.js` file because there is **no root `babel.config.js`** (each workspace has its own). It already fails with thousands of errors on `main` — a new root-level `.js` file (e.g. a config) adds more of the same parse errors but does NOT indicate a real defect. Validate with `yarn lint` (oxlint), not `lint:eslint`. CodeRabbit's "ESLint install failed" warning stems from the same root-eslint fragility and is not a blocker.
+
+**Commit hooks fail headless.** lefthook `commit-msg` runs commitlint which needs a TTY; in a non-interactive shell it errors. Validate the message with `echo "msg" | yarn commitlint`, then commit with `git commit --no-verify`.
+
+**Commits & pushes.** Subject-only messages, empty body unless explicitly asked (enforced by commitlint config-conventional). No AI-authorship trailers (`Co-Authored-By`, `🤖`, etc.). Split changes into feature-sized commits. **Never `git push` or open a PR unless explicitly asked.** Big changes go on a feature branch → PR, never committed straight to `main`.
 
 ### Working In This Directory
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,8 @@ export default defineConfig([
     },
   },
   {
-    ignores: ['node_modules/', 'lib/', 'docs/'],
+    // jest.config.js files are plain config, not source — the @react-native
+    // preset's Babel parser fails on them because there is no root babel.config.js.
+    ignores: ['node_modules/', 'lib/', 'docs/', '**/jest.config.js'],
   },
 ]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // Delegate to each workspace's own jest config so their babel/preset/module
+  // settings stay isolated. A single root config can't serve all of them: the
+  // device-info package transforms react-native's Flow via @react-native/babel-preset,
+  // while mcp-server uses ts-jest in a node env — mixing them breaks one or the other.
+  //
+  // Only workspaces with runnable (non-device) jest suites are listed. Excluded:
+  //   - example/showcase, example/integrity-demo: react-native-harness preset,
+  //     *.harness.* suites need a connected device/runner — not runnable here.
+  //   - react-native-nitro-device-integrity, example/benchmark: no jest suites.
+  projects: [
+    '<rootDir>/packages/react-native-nitro-device-info',
+    '<rootDir>/packages/mcp-server',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -74,13 +74,6 @@
     "picomatch@^4.0.3": "4.0.4"
   },
   "packageManager": "yarn@3.6.1",
-  "jest": {
-    "preset": "react-native",
-    "modulePathIgnorePatterns": [
-      "<rootDir>/example/node_modules",
-      "<rootDir>/packages/react-native-nitro-device-info/lib/"
-    ]
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
## Problem

Root `yarn test` was fully broken (every suite failed, 0 tests ran). Two causes:

1. The root had a `jest` field (`preset: react-native`) but **no `babel.config.js`**, so it could not transform the Flow syntax in `react-native/jest/setup.js` — every suite died with `SyntaxError ... value(id: TimeoutID): void`.
2. With no scoped `testMatch`, the root run mis-collected non-test files: codemod `__testfixtures__/*.input|output.*` (jscodeshift data), the device-only `*.harness.*` suites, and `example/showcase/src/__tests__/types.ts` (a helper).

Per-package `jest` worked (each package has its own babel/preset); only the root aggregate was broken.

## Fix

Convert the root to jest `projects`, delegating to each workspace's own config so babel/preset/module settings stay isolated:

- Add root `jest.config.js` listing the two runnable, non-device workspaces: `packages/react-native-nitro-device-info` (RN preset, `.test.{ts,tsx}`) and `packages/mcp-server` (ts-jest, node).
- Remove the now-conflicting `jest` field from root `package.json` (jest rejects having both a `jest` key and a `jest.config.js`).

Excluded by design (documented in the config):

- `example/showcase`, `example/integrity-demo` use the `react-native-harness` preset; their `*.harness.*` suites need a booted simulator and fail standalone without one, so including them would re-break `yarn test` in CI.
- `react-native-nitro-device-integrity`, `example/benchmark` have no jest suites.

## Follow-up commits

- `chore`: add `**/jest.config.js` to `eslint.config.mjs` ignores. The `@react-native` eslint preset uses a Babel parser that throws `No Babel config file detected` on every `jest.config.js` (no root `babel.config.js`). This already affected the pre-existing workspace `jest.config.js` files; ignoring config files removes those parse errors too. The real lint gate, `yarn lint` (oxlint), passes with 0 errors.
- `docs(agents)`: document the worktree-isolation workflow, Yarn Berry `node-modules` linker, and the `lint` vs `lint:eslint` distinction in `AGENTS.md`.

## Verification

- Root `yarn test`: 8 suites / 141 tests pass, exit 0 (was 0 tests).
- `react-native-nitro-device-info` standalone: 43 tests / 2 suites — unchanged.
- `mcp-server` standalone: 98 tests / 6 suites — unchanged.
- No fixtures, harness files, or helpers collected.
- `yarn lint` (oxlint): 0 errors. `yarn typecheck`: exit 0.