### PR TITLE
feat: add Expo config plugin for prebuild/dev-client users

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -44,6 +44,26 @@ cd ios && pod install && cd ..
 별도의 설정이 필요 없습니다.
 Gradle 자동 링크가 모든 작업을 처리합니다.
 
+### Expo (prebuild / dev client)
+
+```sh
+npx expo install react-native-nitro-device-info react-native-nitro-modules
+```
+
+대부분의 API는 자동 링크만으로 충분합니다. 권한이나 entitlement가 필요한 일부 API는 `app.json`의 config plugin으로 opt-in 합니다:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["react-native-nitro-device-info", { "enableSerialNumber": true }]
+    ]
+  }
+}
+```
+
+이후 `npx expo prebuild --clean`을 실행하세요. 전체 옵션, device-integrity 플러그인, `isSideLoadingEnabled()` 주의사항은 [Expo Setup 가이드](https://l2hyunwoo.github.io/react-native-nitro-device-info/guide/expo-setup)를 참고하세요.
+
 ## 빠른 시작
 
 ### 기본 사용법

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ cd ios && pod install && cd ..
 
 No additional configuration needed! Gradle auto-linking handles everything.
 
+### Expo (prebuild / dev client)
+
+```sh
+npx expo install react-native-nitro-device-info react-native-nitro-modules
+```
+
+Autolinking is enough for most APIs. A few APIs that need a permission or entitlement are opt-in via a config plugin in `app.json`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["react-native-nitro-device-info", { "enableSerialNumber": true }]
+    ]
+  }
+}
+```
+
+Then run `npx expo prebuild --clean`. See the [Expo Setup guide](https://l2hyunwoo.github.io/react-native-nitro-device-info/guide/expo-setup) for all options, the device-integrity plugin, and the `isSideLoadingEnabled()` caveat.
+
 ## Quick Start
 
 ### Basic Usage

--- a/docs/docs/guide/expo-setup.md
+++ b/docs/docs/guide/expo-setup.md
@@ -1,0 +1,102 @@
+# Expo Setup
+
+If you use Expo with [Continuous Native Generation](https://docs.expo.dev/workflow/continuous-native-generation/) (`expo prebuild` / dev client), `react-native-nitro-device-info` ships **config plugins** so you can adopt it without editing `ios/` or `android/` by hand.
+
+The library is a Nitro module, so it requires the **New Architecture**. New Architecture is enabled by default on Expo SDK 52 and later, so no extra step is needed there.
+
+## Install
+
+```bash
+npx expo install react-native-nitro-device-info react-native-nitro-modules
+```
+
+Autolinking registers the native module — for most APIs that is all you need, and you can run `npx expo prebuild` without listing any plugin.
+
+## When you need the config plugin
+
+A few APIs read native capabilities that require a permission or an entitlement. Those are **opt-in**: the plugin only adds them when you ask, because requesting permissions you do not use can get an app rejected from the stores. Add the plugin to the `plugins` array in `app.json` (or `app.config.js`) and enable what you need:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-nitro-device-info",
+        {
+          "enableSerialNumber": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+Then regenerate the native projects:
+
+```bash
+npx expo prebuild --clean
+```
+
+### Plugin options
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `enableSerialNumber` | `false` | Adds the Android `READ_PHONE_STATE` permission so `serialNumber` returns the real serial on Android 8.0+. Without it, `serialNumber` returns `"unknown"`. |
+
+`READ_PHONE_STATE` is a sensitive permission. Enable it only if you read `serialNumber`, and declare it in your Play Console Data Safety form.
+
+### What is NOT injected (by design)
+
+- **`getInstallReferrer()`, `getHasGms()`** — the Play Install Referrer and Google Play Services dependencies are bundled in the library's Gradle build, so the consuming app needs no manifest or Gradle change.
+- **Location and carrier APIs** — `getIsLocationEnabled()` and the carrier getters read global system state without requesting authorization, so they need no `Info.plist` usage-description keys.
+- **`isSideLoadingEnabled()`** — see below.
+
+## `isSideLoadingEnabled()` requires manual setup
+
+`isSideLoadingEnabled()` calls `canRequestPackageInstalls()`, which only returns `true` when the app declares the Android `REQUEST_INSTALL_PACKAGES` permission. The plugin does **not** add this permission, because Google Play classifies it as a restricted permission: it is only an acceptable use when your app actually installs packages with user-initiated flows. Declaring it just to query sideloading status can fail Play review.
+
+If your app genuinely qualifies, add the permission yourself with the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/build-properties/) plugin or a small custom plugin, and be ready to justify it in the Play Console permissions declaration. Without the permission, `isSideLoadingEnabled()` simply returns `false`.
+
+## Device attestation (App Attest / Play Integrity)
+
+The optional `react-native-nitro-device-integrity` package has its own config plugin.
+
+```bash
+npx expo install react-native-nitro-device-integrity
+```
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-nitro-device-integrity",
+        {
+          "appAttest": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `appAttest` | `false` | Adds the iOS `com.apple.developer.devicecheck.appattest-environment` entitlement (value `development`) so `DCAppAttestService` works. |
+
+The entitlement value is always written as `development`. iOS ignores it on builds distributed through TestFlight or the App Store and uses the production environment automatically, so a single value is correct for both.
+
+:::warning App Attest also needs a portal capability
+The plugin writes the entitlement, but it cannot enable the App Attest capability on your App ID. Turn on **App Attest** for your App ID in the Apple Developer portal (or let EAS / Xcode automatic signing manage it). Without that capability the build fails to sign (error `0xE8008016`).
+:::
+
+Play Integrity (Android) and DeviceCheck (iOS) need no entitlement or permission — only a runtime `cloudProjectNumber` for Play Integrity — so they require no config plugin.
+
+## Verifying the result
+
+After `npx expo prebuild --clean`, you can confirm the injected settings:
+
+- `android/app/src/main/AndroidManifest.xml` contains `<uses-permission android:name="android.permission.READ_PHONE_STATE" />` when `enableSerialNumber` is on.
+- `ios/<app>/<app>.entitlements` contains the `appattest-environment` key when `appAttest` is on.
+
+Running prebuild again does not duplicate these entries — the plugins are idempotent.

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
           { text: 'Introduction', link: '/guide/introduction' },
           { text: 'Why Nitro Module', link: '/guide/why-nitro-module' },
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Expo Setup', link: '/guide/expo-setup' },
           { text: 'Quick Start', link: '/guide/quick-start' },
           { text: 'React Hooks', link: '/guide/react-hooks' },
           { text: 'Web Support', link: '/guide/web-support' },

--- a/packages/react-native-nitro-device-info/app.plugin.js
+++ b/packages/react-native-nitro-device-info/app.plugin.js
@@ -1,0 +1,5 @@
+// Expo resolves "react-native-nitro-device-info" to this file and require()s it
+// synchronously as CommonJS, expecting module.exports to be the plugin function.
+// The plugin is built to CommonJS under plugin/build (separate from the library's
+// ESM-only bob output); .default unwraps the tsc esModuleInterop export.
+module.exports = require('./plugin/build/withDeviceInfo').default;

--- a/packages/react-native-nitro-device-info/package.json
+++ b/packages/react-native-nitro-device-info/package.json
@@ -30,6 +30,8 @@
     "nitro.json",
     "*.podspec",
     "react-native.config.js",
+    "app.plugin.js",
+    "plugin/build",
     "!ios/build",
     "!android/build",
     "!android/gradle",
@@ -42,11 +44,12 @@
     "!**/.*"
   ],
   "scripts": {
-    "prepare": "bob build",
+    "prepare": "bob build && yarn build:plugin",
+    "build:plugin": "tsc --project plugin/tsconfig.json",
     "nitrogen": "nitrogen",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "clean": "del-cli lib nitrogen/generated android/build ios/build"
+    "clean": "del-cli lib nitrogen/generated android/build ios/build plugin/build"
   },
   "keywords": [
     "react-native",
@@ -72,6 +75,7 @@
     "react-native-nitro-modules": ">=0.35.0 <1.0.0"
   },
   "devDependencies": {
+    "@expo/config-plugins": "^10.0.0",
     "@types/jscodeshift": "17.3.0",
     "del-cli": "7.0.0",
     "jest": "30.2.0",

--- a/packages/react-native-nitro-device-info/package.json
+++ b/packages/react-native-nitro-device-info/package.json
@@ -31,7 +31,7 @@
     "*.podspec",
     "react-native.config.js",
     "app.plugin.js",
-    "plugin/build",
+    "plugin/build/**",
     "!ios/build",
     "!android/build",
     "!android/gradle",

--- a/packages/react-native-nitro-device-info/plugin/src/types.ts
+++ b/packages/react-native-nitro-device-info/plugin/src/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Options for the react-native-nitro-device-info Expo config plugin.
+ *
+ * Every native capability that needs an extra permission is opt-in and
+ * defaults to off — declaring permissions a user does not need risks Play
+ * Store / App Store rejection.
+ */
+export type DeviceInfoPluginProps = {
+  /**
+   * Add the Android `READ_PHONE_STATE` permission so `serialNumber` can return
+   * the real device serial on Android 8.0+ (`Build.getSerial()` is guarded by
+   * this runtime permission). Without it, `serialNumber` returns `"unknown"`.
+   *
+   * `READ_PHONE_STATE` is a sensitive permission — only enable this if you
+   * actually read `serialNumber`, and be ready to justify it in your Play
+   * Data Safety form.
+   *
+   * @default false
+   */
+  enableSerialNumber?: boolean;
+};

--- a/packages/react-native-nitro-device-info/plugin/src/withDeviceInfo.ts
+++ b/packages/react-native-nitro-device-info/plugin/src/withDeviceInfo.ts
@@ -1,0 +1,21 @@
+import { type ConfigPlugin, createRunOncePlugin, withPlugins } from '@expo/config-plugins';
+
+import type { DeviceInfoPluginProps } from './types';
+import { withSerialNumber } from './withSerialNumber';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../../package.json') as { name: string; version: string };
+
+const withDeviceInfo: ConfigPlugin<DeviceInfoPluginProps> = (config, props = {}) => {
+  const plugins: ConfigPlugin[] = [];
+
+  if (props.enableSerialNumber) {
+    plugins.push(withSerialNumber);
+  }
+
+  return withPlugins(config, plugins);
+};
+
+// createRunOncePlugin keys on pkg.name, so listing the plugin more than once
+// (or via autolinking + an explicit entry) applies the native changes once.
+export default createRunOncePlugin(withDeviceInfo, pkg.name, pkg.version);

--- a/packages/react-native-nitro-device-info/plugin/src/withSerialNumber.ts
+++ b/packages/react-native-nitro-device-info/plugin/src/withSerialNumber.ts
@@ -1,0 +1,13 @@
+import { AndroidConfig, type ConfigPlugin, withPlugins } from '@expo/config-plugins';
+
+/**
+ * Adds `android.permission.READ_PHONE_STATE` to the Android manifest.
+ *
+ * Delegates to the high-level `AndroidConfig.Permissions.withPermissions`,
+ * which is idempotent (it only adds a `<uses-permission>` that is not already
+ * present), so repeated prebuilds never duplicate the entry.
+ */
+export const withSerialNumber: ConfigPlugin = (config) =>
+  withPlugins(config, [
+    [AndroidConfig.Permissions.withPermissions, ['android.permission.READ_PHONE_STATE']],
+  ]);

--- a/packages/react-native-nitro-device-info/plugin/tsconfig.json
+++ b/packages/react-native-nitro-device-info/plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": false,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/react-native-nitro-device-integrity/app.plugin.js
+++ b/packages/react-native-nitro-device-integrity/app.plugin.js
@@ -1,0 +1,5 @@
+// Expo resolves "react-native-nitro-device-integrity" to this file and require()s
+// it synchronously as CommonJS, expecting module.exports to be the plugin function.
+// The plugin is built to CommonJS under plugin/build; .default unwraps the tsc
+// esModuleInterop export.
+module.exports = require('./plugin/build/withDeviceIntegrity').default;

--- a/packages/react-native-nitro-device-integrity/package.json
+++ b/packages/react-native-nitro-device-integrity/package.json
@@ -23,7 +23,7 @@
     "*.podspec",
     "react-native.config.js",
     "app.plugin.js",
-    "plugin/build",
+    "plugin/build/**",
     "!ios/build",
     "!android/build",
     "!android/gradle",

--- a/packages/react-native-nitro-device-integrity/package.json
+++ b/packages/react-native-nitro-device-integrity/package.json
@@ -22,6 +22,8 @@
     "nitro.json",
     "*.podspec",
     "react-native.config.js",
+    "app.plugin.js",
+    "plugin/build",
     "!ios/build",
     "!android/build",
     "!android/gradle",
@@ -34,10 +36,11 @@
     "!**/.*"
   ],
   "scripts": {
-    "prepare": "bob build",
+    "prepare": "bob build && yarn build:plugin",
+    "build:plugin": "tsc --project plugin/tsconfig.json",
     "nitrogen": "nitrogen",
     "typecheck": "tsc --noEmit",
-    "clean": "del-cli lib nitrogen/generated android/build ios/build"
+    "clean": "del-cli lib nitrogen/generated android/build ios/build plugin/build"
   },
   "keywords": [
     "react-native",
@@ -68,6 +71,7 @@
     "react-native-nitro-modules": ">=0.35.0 <1.0.0"
   },
   "devDependencies": {
+    "@expo/config-plugins": "^10.0.0",
     "del-cli": "7.0.0",
     "nitrogen": "0.35.0",
     "react-native-builder-bob": "0.40.18",

--- a/packages/react-native-nitro-device-integrity/plugin/src/types.ts
+++ b/packages/react-native-nitro-device-integrity/plugin/src/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Options for the react-native-nitro-device-integrity Expo config plugin.
+ */
+export type DeviceIntegrityPluginProps = {
+  /**
+   * Enable iOS App Attest (`DCAppAttestService`) by adding the
+   * `com.apple.developer.devicecheck.appattest-environment` entitlement.
+   *
+   * When `true`, the entitlement is written with the value `"development"`.
+   * iOS ignores this value on builds distributed via TestFlight / the App
+   * Store and always uses the production environment, so a single static value
+   * is correct for both development and release — no per-configuration split.
+   *
+   * NOTE: this only writes the entitlement. You must also enable the App Attest
+   * capability for your App ID in the Apple Developer portal (or via automatic
+   * signing); otherwise the build fails to sign (error 0xE8008016). Play
+   * Integrity (Android) and DeviceCheck (iOS) need no entitlement and work
+   * without this flag.
+   *
+   * @default false
+   */
+  appAttest?: boolean;
+};

--- a/packages/react-native-nitro-device-integrity/plugin/src/withAppAttestEntitlement.ts
+++ b/packages/react-native-nitro-device-integrity/plugin/src/withAppAttestEntitlement.ts
@@ -1,0 +1,16 @@
+import { type ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
+
+const APP_ATTEST_ENTITLEMENT = 'com.apple.developer.devicecheck.appattest-environment';
+
+/**
+ * Writes the App Attest environment entitlement. Setting a key on the
+ * entitlements plist is inherently idempotent across repeated prebuilds.
+ *
+ * `development` is the value Xcode writes when the App Attest capability is
+ * toggled on; iOS overrides it to production on distributed builds.
+ */
+export const withAppAttestEntitlement: ConfigPlugin = (config) =>
+  withEntitlementsPlist(config, (cfg) => {
+    cfg.modResults[APP_ATTEST_ENTITLEMENT] = 'development';
+    return cfg;
+  });

--- a/packages/react-native-nitro-device-integrity/plugin/src/withDeviceIntegrity.ts
+++ b/packages/react-native-nitro-device-integrity/plugin/src/withDeviceIntegrity.ts
@@ -1,0 +1,19 @@
+import { type ConfigPlugin, createRunOncePlugin, withPlugins } from '@expo/config-plugins';
+
+import type { DeviceIntegrityPluginProps } from './types';
+import { withAppAttestEntitlement } from './withAppAttestEntitlement';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('../../package.json') as { name: string; version: string };
+
+const withDeviceIntegrity: ConfigPlugin<DeviceIntegrityPluginProps> = (config, props = {}) => {
+  const plugins: ConfigPlugin[] = [];
+
+  if (props.appAttest) {
+    plugins.push(withAppAttestEntitlement);
+  }
+
+  return withPlugins(config, plugins);
+};
+
+export default createRunOncePlugin(withDeviceIntegrity, pkg.name, pkg.version);

--- a/packages/react-native-nitro-device-integrity/plugin/tsconfig.json
+++ b/packages/react-native-nitro-device-integrity/plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": false,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:~7.10.4":
+  version: 7.10.4
+  resolution: "@babel/code-frame@npm:7.10.4"
+  dependencies:
+    "@babel/highlight": ^7.10.4
+  checksum: feb4543c8a509fe30f0f6e8d7aa84f82b41148b963b826cd330e34986f649a85cb63b2f13dd4effdf434ac555d16f14940b8ea5f4433297c2f5ff85486ded019
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.27.2, @babel/compat-data@npm:^7.27.7, @babel/compat-data@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/compat-data@npm:7.28.5"
@@ -531,17 +540,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: cc7779e96fe9c9478c96ca4bf04fc338b95b501aa5abe78178307dea282d4a5dc23d443efb12dde8e8c5636d03dd00e443532e6ed7f15fa7977349af1f87ba4d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.27.1, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 5a251a6848e9712aea0338f659a1a3bd334d26219d5511164544ca8ec20774f098c3a6661e9da65a0d085c745c00bb62c8fada38a62f08fa1f8053bc0aeb57e4
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
-  checksum: cc7779e96fe9c9478c96ca4bf04fc338b95b501aa5abe78178307dea282d4a5dc23d443efb12dde8e8c5636d03dd00e443532e6ed7f15fa7977349af1f87ba4d
   languageName: node
   linkType: hard
 
@@ -597,6 +606,18 @@ __metadata:
     "@babel/template": ^7.29.7
     "@babel/types": ^7.29.7
   checksum: b5c4ed0ce5983c5599cd01b3948444b77ba2fa47bf6282a82afdcbe45eb8cc5b7986194e3920ef2760f533c6a775504e6b00a66960c0a3bc52909920b8433908
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.10.4":
+  version: 7.25.9
+  resolution: "@babel/highlight@npm:7.25.9"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.25.9
+    chalk: ^2.4.2
+    js-tokens: ^4.0.0
+    picocolors: ^1.0.0
+  checksum: a6e0ac0a1c4bef7401915ca3442ab2b7ae4adf360262ca96b91396bfb9578abb28c316abf5e34460b780696db833b550238d9256bdaca60fade4ba7a67645064
   languageName: node
   linkType: hard
 
@@ -2369,6 +2390,63 @@ __metadata:
     lefthook: bin/index.js
   checksum: a6678a35910117d03c972d4bb86699276593466100441686209d2b5634cbc6e0426f31d6103fb29520d0dc65876057e2dba4e61a2194766d0199d5905f75f40d
   conditions: (os=darwin | os=linux | os=win32) & (cpu=x64 | cpu=arm64 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@expo/config-plugins@npm:^10.0.0":
+  version: 10.1.2
+  resolution: "@expo/config-plugins@npm:10.1.2"
+  dependencies:
+    "@expo/config-types": ^53.0.5
+    "@expo/json-file": ~9.1.5
+    "@expo/plist": ^0.3.5
+    "@expo/sdk-runtime-versions": ^1.0.0
+    chalk: ^4.1.2
+    debug: ^4.3.5
+    getenv: ^2.0.0
+    glob: ^10.4.2
+    resolve-from: ^5.0.0
+    semver: ^7.5.4
+    slash: ^3.0.0
+    slugify: ^1.6.6
+    xcode: ^3.0.1
+    xml2js: 0.6.0
+  checksum: 861a6e814aa8dba9c4d27939dbcb9dcd177e46b7e26c158deee549e8992575ea8779f4d6e61024c8f5880f86e3d029de20adac99e3918b5af9caefb5d53ac6cb
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^53.0.5":
+  version: 53.0.5
+  resolution: "@expo/config-types@npm:53.0.5"
+  checksum: 3f4db2d9590c18fb178f7395739ee2200512ad7c253655be0bad7f3f0d948df89c1c69c7e949f202faa98eecbd4bbae3edfcf9264f97f49d4f7087f85c68af5d
+  languageName: node
+  linkType: hard
+
+"@expo/json-file@npm:~9.1.5":
+  version: 9.1.5
+  resolution: "@expo/json-file@npm:9.1.5"
+  dependencies:
+    "@babel/code-frame": ~7.10.4
+    json5: ^2.2.3
+  checksum: beedf9077dcff476acd895219e391e18079d3c375e58bb4902a4147fffe9774e11d4d1607cfc3488f8e9daec2c30e4d7c17c46fb701035ad7aabacaaf6d465b4
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@expo/plist@npm:0.3.5"
+  dependencies:
+    "@xmldom/xmldom": ^0.8.8
+    base64-js: ^1.2.3
+    xmlbuilder: ^15.1.1
+  checksum: b78fda216c63ab553b24e75e87021be09155cd16e0fcf666846c1a5ea33defa2d7f631ea504788a8e2c5d67b5f59b35d6a46fa79a244d5890ee26870caffec22
+  languageName: node
+  linkType: hard
+
+"@expo/sdk-runtime-versions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@expo/sdk-runtime-versions@npm:1.0.0"
+  checksum: 0942d5a356f590e8dc795761456cc48b3e2d6a38ad2a02d6774efcdc5a70424e05623b4e3e5d2fec0cdc30f40dde05c14391c781607eed3971bf8676518bfd9d
   languageName: node
   linkType: hard
 
@@ -4543,6 +4621,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 420f3ba52316163384ce626cda087d06b0eb5888d393b00bbc5f56489bbaccc8633e9b078942ee05facda93fbf813b209a5deb5044f89a6e04373305a0e573c0
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -4700,7 +4792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0":
+"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -5158,7 +5250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.2.3, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -5171,6 +5263,13 @@ __metadata:
   bin:
     baseline-browser-mapping: dist/cli.js
   checksum: b26d79ca391037581575989675cc21155e3b4925745d3481bf936a1ce22f054cc9e0e67e938b692c305389b4996aecb3ad9ffaa5cda7f28f7db060c777bf4799
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:1.6.x":
+  version: 1.6.52
+  resolution: "big-integer@npm:1.6.52"
+  checksum: 6e86885787a20fed96521958ae9086960e4e4b5e74d04f3ef7513d4d0ad631a9f3bde2730fc8aaa4b00419fc865f6ec573e5320234531ef37505da7da192c40b
   languageName: node
   linkType: hard
 
@@ -5226,6 +5325,24 @@ __metadata:
     raw-body: ^3.0.1
     type-is: ^2.0.1
   checksum: 4a111af3534e6a5d37e8b98c23da403d5d1f046a24546193a417b2a4da7c52ee7c367f18cea73638fa25b8699b02923948bc4b55f366b879d3ca8ede49e201aa
+  languageName: node
+  linkType: hard
+
+"bplist-creator@npm:0.1.1":
+  version: 0.1.1
+  resolution: "bplist-creator@npm:0.1.1"
+  dependencies:
+    stream-buffers: 2.2.x
+  checksum: b0d40d1d1623f1afdbb575cfc8075d742d2c4f0eb458574be809e3857752d1042a39553b3943d2d7f505dde92bcd43e1d7bdac61c9cd44475d696deb79f897ce
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:0.3.2":
+  version: 0.3.2
+  resolution: "bplist-parser@npm:0.3.2"
+  dependencies:
+    big-integer: 1.6.x
+  checksum: fad0f6eb155a9b636b4096a1725ce972a0386490d7d38df7be11a3a5645372446b7c44aacbc6626d24d2c17d8b837765361520ebf2960aeffcaf56765811620e
   languageName: node
   linkType: hard
 
@@ -5403,6 +5520,17 @@ __metadata:
     loupe: ^3.1.0
     pathval: ^2.0.0
   checksum: bc4091f1cccfee63f6a3d02ce477fe847f5c57e747916a11bd72675c9459125084e2e55dc2363ee2b82b088a878039ee7ee27c75d6d90f7de9202bf1b12ce573
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
   languageName: node
   linkType: hard
 
@@ -7365,6 +7493,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"getenv@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "getenv@npm:2.0.0"
+  checksum: d5e4cd001952db17d546c8ae5961b68dd83d0a6c6027cc4c613cbe0f88ca835f661364a7eff32428953e7677af95fb0a35f035c98b661bef2fcabb5d7c711c86
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^4.0.0":
   version: 4.0.0
   resolution: "git-raw-commits@npm:4.0.0"
@@ -7396,7 +7531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.10, glob@npm:^10.5.0":
+"glob@npm:^10.3.10, glob@npm:^10.4.2, glob@npm:^10.5.0":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -7534,6 +7669,13 @@ __metadata:
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
   checksum: 79730518ae02c77e4af6a1d1a0b6a2c3e1509785532771f9baf0241e83e36329542c3d7a0e723df8cbc85f74eff4f177828a2265a01ba576adbdc2d40d86538b
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
   languageName: node
   linkType: hard
 
@@ -10994,6 +11136,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plist@npm:^3.0.5":
+  version: 3.1.1
+  resolution: "plist@npm:3.1.1"
+  dependencies:
+    "@xmldom/xmldom": ^0.9.10
+    base64-js: ^1.5.1
+    xmlbuilder: ^15.1.1
+  checksum: 775b2befb6df97b145193e5c241dc63929c58c89673eebc51e06b4b5b3403d15d921140278644ddf6f51a6936d46450d35903a84fc4cba071c46d9c33141817d
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -11388,6 +11541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-nitro-device-info@workspace:packages/react-native-nitro-device-info"
   dependencies:
+    "@expo/config-plugins": ^10.0.0
     "@types/jscodeshift": 17.3.0
     del-cli: 7.0.0
     jest: 30.2.0
@@ -11436,6 +11590,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-nitro-device-integrity@workspace:packages/react-native-nitro-device-integrity"
   dependencies:
+    "@expo/config-plugins": ^10.0.0
     del-cli: 7.0.0
     nitrogen: 0.35.0
     react-native-builder-bob: 0.40.18
@@ -11850,6 +12005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 83ae2a17f524bd35b1b7d1c867700b1fab41e4cbb4f7635b7e66398421e06ff2cd43ec651c151cb99c67c3681ec7d0493cb6a98fd2e7799ea15b5d0a4615f870
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
@@ -12100,6 +12262,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-plist@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "simple-plist@npm:1.4.0"
+  dependencies:
+    bplist-creator: 0.1.1
+    bplist-parser: 0.3.2
+    plist: ^3.0.5
+  checksum: fa8086f6b781c289f1abad21306481dda4af6373b32a5d998a70e53c2b7218a1d21ebb5ae3e736baae704c21d311d3d39d01d0e6a2387eda01b4020b9ebd909e
+  languageName: node
+  linkType: hard
+
 "sinon@npm:^21.0.0":
   version: 21.0.0
   resolution: "sinon@npm:21.0.0"
@@ -12142,6 +12315,13 @@ __metadata:
     astral-regex: ^1.0.0
     is-fullwidth-code-point: ^2.0.0
   checksum: 4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.6":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: ace83853caefa3a3284c9e66cc85175ec8420ba60fbab75b996c4077d6187a98443f59fffee170f5e0ed448d238fae4653f6afae29b046a1eb029359033e2fb6
   languageName: node
   linkType: hard
 
@@ -12283,6 +12463,13 @@ __metadata:
     es-errors: ^1.3.0
     internal-slot: ^1.1.0
   checksum: be944489d8829fb3bdec1a1cc4a2142c6b6eb317305eeace1ece978d286d6997778afa1ae8cb3bd70e2b274b9aa8c69f93febb1e15b94b1359b11058f9d3c3a1
+  languageName: node
+  linkType: hard
+
+"stream-buffers@npm:2.2.x":
+  version: 2.2.0
+  resolution: "stream-buffers@npm:2.2.0"
+  checksum: 4587d9e8f050d689fb38b4295e73408401b16de8edecc12026c6f4ae92956705ecfd995ae3845d7fa3ebf19502d5754df9143d91447fd881d86e518f43882c1c
   languageName: node
   linkType: hard
 
@@ -12466,6 +12653,15 @@ __metadata:
   version: 1.1.2
   resolution: "strnum@npm:1.1.2"
   checksum: a85219eda13e97151c95e343a9e5960eacfb0a0ff98104b4c9cb7a212e3008bddf0c9714c9c37c2e508be78e741a04afc80027c2dc18509d1b5ffd4c37191fc2
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: ^3.0.0
+  checksum: 95f6f4ba5afdf92f495b5a912d4abee8dcba766ae719b975c56c084f5004845f6f5a5f7769f52d53f40e21952a6d87411bafe34af4a01e65f9926002e38e1dac
   languageName: node
   linkType: hard
 
@@ -13096,6 +13292,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: f5b7b5cc28accac68d5c083fd51cca64896639ebd4cca88c6cfb363801aaa83aa439c86dfc8446ea250a7a98d17afd2ad9e88d9d4958c79a412eccb93bae29de
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -13375,6 +13580,40 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
+  languageName: node
+  linkType: hard
+
+"xcode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "xcode@npm:3.0.1"
+  dependencies:
+    simple-plist: ^1.1.0
+    uuid: ^7.0.3
+  checksum: 908ff85851f81aec6e36ca24427db092e1cc068f052716e14de5e762196858039efabbe053a1abe8920184622501049e74a93618e8692b982f7604a9847db108
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.0":
+  version: 0.6.0
+  resolution: "xml2js@npm:0.6.0"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 437f353fd66d367bf158e9555a0625df9965d944e499728a5c6bc92a54a2763179b144f14b7e1c725040f56bbd22b0fa6cfcb09ec4faf39c45ce01efe631f40b
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:^15.1.1":
+  version: 15.1.1
+  resolution: "xmlbuilder@npm:15.1.1"
+  checksum: 14f7302402e28d1f32823583d121594a9dca36408d40320b33f598bd589ca5163a352d076489c9c64d2dc1da19a790926a07bf4191275330d4de2b0d85bb1843
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Adds Expo config plugins to both packages so Expo prebuild / dev-client users can adopt the library without editing `ios/` or `android/` by hand.

- `react-native-nitro-device-info` → `withDeviceInfo`
- `react-native-nitro-device-integrity` → `withDeviceIntegrity`

## Why

`expo-device` users are mostly on the prebuild / CNG workflow. Without a config plugin, adopting a native module means hand-editing native projects or ejecting. The plugins inject the required permission/entitlement declaratively via `app.json`.

## What gets injected (opt-in only)

Permissions/entitlements are opt-in and default to off — requesting permissions a user does not need risks store rejection. Most of the library needs no plugin at all (autolinking is enough).

| API | Native requirement | Plugin handling |
| --- | --- | --- |
| `serialNumber` | Android `READ_PHONE_STATE` | `enableSerialNumber` prop (default `false`) |
| App Attest (integrity) | iOS `com.apple.developer.devicecheck.appattest-environment` | `appAttest` prop (default `false`, value `development`) |
| `getInstallReferrer()`, `getHasGms()` | Gradle deps bundled in the library | none needed |
| Location / carrier (iOS) | global checks, no authorization request | no `Info.plist` key needed |
| `isSideLoadingEnabled()` | Android `REQUEST_INSTALL_PACKAGES` | not injected — see below |

### `isSideLoadingEnabled()` is documented, not injected

`REQUEST_INSTALL_PACKAGES` is a Google Play restricted permission; declaring it only to query sideloading status is not an acceptable use and can fail Play review. The plugin does not add it. The Expo Setup guide explains the manual path for apps that genuinely qualify. Without the permission the API returns `false`.

## Implementation notes

- Plugin sources live in `plugin/src/` and build to CommonJS in `plugin/build/` via a dedicated `tsc` step, because the library's builder-bob output is ESM-only and Expo `require()`s `app.plugin.js` synchronously as CommonJS. The root `app.plugin.js` is a thin shim.
- `createRunOncePlugin` keeps the native changes idempotent.
- `files[]` ships `plugin/build/**` and `app.plugin.js`; `@expo/config-plugins` is a devDependency (Expo provides it at prebuild time).

## App Attest caveat

The plugin writes the entitlement but cannot enable the App Attest capability on the App ID — that is done in the Apple Developer portal or via EAS/Xcode automatic signing. This is called out in the docs.

## Verification

Validated against a throwaway Expo app (SDK 56, RN 0.85.3, New Architecture on) with `expo prebuild --clean`:

- `enableSerialNumber: true` → `READ_PHONE_STATE` in `AndroidManifest.xml`
- `appAttest: true` → `appattest-environment = development` in the entitlements file
- props off / bare string → nothing injected
- `REQUEST_INSTALL_PACKAGES` never injected; no `NSLocation*` keys leaked
- idempotent across `--clean` re-runs and a non-clean re-apply (each entry appears once)
- packed tarballs ship the plugin; `require('./app.plugin.js')` resolves to a function in the extracted layout

Docs build (rspress) and package typechecks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Expo (prebuild/dev client) support with configurable device-info and device-integrity plugins

* **Documentation**
  * Added comprehensive Expo setup guide with examples for enabling serial number access and iOS App Attest entitlements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->