### PR TITLE
fix: native-only DeviceInfoModule proxy + iOS getCarrier bugs, add compat e2e

### DIFF
--- a/example/showcase/src/__tests__/compat-core.harness.ts
+++ b/example/showcase/src/__tests__/compat-core.harness.ts
@@ -1,0 +1,248 @@
+/**
+ * E2E Tests: react-native-device-info (RNDI) compatibility layer
+ *
+ * Validates the `react-native-nitro-device-info/compat` drop-in surface against
+ * the real native module on a device/simulator. The Jest unit tests for compat
+ * run against a mocked native module, so they verify wiring/shape only — these
+ * tests verify the transforms behave correctly with actual native values and
+ * that compat getters agree with the core `DeviceInfoModule`.
+ */
+
+import { describe, test, expect } from 'react-native-harness';
+import { Platform } from 'react-native';
+import { DeviceInfoModule } from 'react-native-nitro-device-info';
+import DeviceInfo, * as compat from 'react-native-nitro-device-info/compat';
+
+describe('compat: async getters resolve and agree with core', () => {
+  test('getUniqueId resolves to the core uniqueId', async () => {
+    const result = compat.getUniqueId();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBe(DeviceInfoModule.uniqueId);
+  });
+
+  test('getManufacturer resolves to the core manufacturer', async () => {
+    await expect(compat.getManufacturer()).resolves.toBe(
+      DeviceInfoModule.manufacturer
+    );
+    if (Platform.OS === 'ios') {
+      await expect(compat.getManufacturer()).resolves.toBe('Apple');
+    }
+  });
+
+  test('getBatteryLevel resolves to a number in [0, 1]', async () => {
+    const value = await compat.getBatteryLevel();
+    expect(typeof value).toBe('number');
+    expect(value).toBeGreaterThanOrEqual(0);
+    expect(value).toBeLessThanOrEqual(1);
+  });
+
+  test('isEmulator resolves to a boolean matching core', async () => {
+    const value = await compat.isEmulator();
+    expect(typeof value).toBe('boolean');
+    expect(value).toBe(DeviceInfoModule.isEmulator);
+  });
+});
+
+describe('compat: sync variants return bare values, not Promises', () => {
+  test('getUniqueIdSync returns a string equal to core', () => {
+    const value = compat.getUniqueIdSync();
+    expect(value).not.toBeInstanceOf(Promise);
+    expect(typeof value).toBe('string');
+    expect(value).toBe(DeviceInfoModule.uniqueId);
+  });
+
+  test('isEmulatorSync returns a bare boolean', () => {
+    const value = compat.isEmulatorSync();
+    expect(typeof value).toBe('boolean');
+    expect(value).toBe(DeviceInfoModule.isEmulator);
+  });
+
+  test('getManufacturerSync returns a bare string', () => {
+    expect(compat.getManufacturerSync()).toBe(DeviceInfoModule.manufacturer);
+  });
+
+  test('async and sync variants return the same value', async () => {
+    await expect(compat.getUniqueId()).resolves.toBe(compat.getUniqueIdSync());
+    await expect(compat.isEmulator()).resolves.toBe(compat.isEmulatorSync());
+  });
+});
+
+describe('compat: property getters expose core readonly values', () => {
+  test('getModel / getBrand / getDeviceId match core', () => {
+    expect(compat.getModel()).toBe(DeviceInfoModule.model);
+    expect(compat.getBrand()).toBe(DeviceInfoModule.brand);
+    expect(compat.getDeviceId()).toBe(DeviceInfoModule.deviceId);
+  });
+
+  test('app metadata getters match core', () => {
+    expect(compat.getVersion()).toBe(DeviceInfoModule.version);
+    expect(compat.getBuildNumber()).toBe(DeviceInfoModule.buildNumber);
+    expect(compat.getBundleId()).toBe(DeviceInfoModule.bundleId);
+    expect(compat.getApplicationName()).toBe(DeviceInfoModule.applicationName);
+    expect(compat.getReadableVersion()).toBe(DeviceInfoModule.readableVersion);
+  });
+});
+
+describe('compat: renamed / aliased methods hit the right core path', () => {
+  test('hasNotch maps to core getHasNotch', () => {
+    const value = compat.hasNotch();
+    expect(typeof value).toBe('boolean');
+    expect(value).toBe(DeviceInfoModule.getHasNotch());
+  });
+
+  test('hasDynamicIsland maps to core getHasDynamicIsland', () => {
+    const value = compat.hasDynamicIsland();
+    expect(typeof value).toBe('boolean');
+    expect(value).toBe(DeviceInfoModule.getHasDynamicIsland());
+  });
+
+  test('isBatteryCharging (async) and isBatteryChargingSync map to core', async () => {
+    const core = DeviceInfoModule.getIsBatteryCharging();
+    await expect(compat.isBatteryCharging()).resolves.toBe(core);
+    expect(compat.isBatteryChargingSync()).toBe(core);
+  });
+
+  test('isAirplaneMode wraps async; isAirplaneModeSync renames', async () => {
+    const value = await compat.isAirplaneMode();
+    expect(typeof value).toBe('boolean');
+    expect(typeof compat.isAirplaneModeSync()).toBe('boolean');
+    if (Platform.OS === 'ios') {
+      expect(value).toBe(false);
+    }
+  });
+});
+
+describe('compat: location providers transform array -> map', () => {
+  test('getAvailableLocationProviders resolves to a map shape', async () => {
+    const providers = await compat.getAvailableLocationProviders();
+    expect(Array.isArray(providers)).toBe(false);
+    expect(typeof providers).toBe('object');
+
+    // Every key from the core array must be present and true.
+    const coreArray = DeviceInfoModule.getAvailableLocationProviders();
+    for (const name of coreArray) {
+      expect(providers[name]).toBe(true);
+    }
+    // Every value in the map must be a boolean true.
+    Object.values(providers).forEach((v) => expect(v).toBe(true));
+  });
+
+  test('getAvailableLocationProvidersSync returns the same map shape', () => {
+    const providers = compat.getAvailableLocationProvidersSync();
+    expect(Array.isArray(providers)).toBe(false);
+    expect(typeof providers).toBe('object');
+  });
+});
+
+describe('compat: getFreeDiskStorage accepts and ignores storageType', () => {
+  // The storageType argument must be accepted (RNDI signature parity) and
+  // ignored — passing it must not change the query path. Free disk space can
+  // drift by a few KB between back-to-back native calls (the OS writes), so we
+  // assert both calls return a valid number rather than byte-exact equality.
+  test('async variant accepts the storageType argument', async () => {
+    const noArg = await compat.getFreeDiskStorage();
+    const withArg = await compat.getFreeDiskStorage('important');
+    expect(typeof noArg).toBe('number');
+    expect(noArg).toBeGreaterThan(0);
+    expect(typeof withArg).toBe('number');
+    expect(withArg).toBeGreaterThan(0);
+  });
+
+  test('sync variant accepts the storageType argument', () => {
+    const noArg = compat.getFreeDiskStorageSync();
+    const withArg = compat.getFreeDiskStorageSync('opportunistic');
+    expect(typeof noArg).toBe('number');
+    expect(noArg).toBeGreaterThan(0);
+    expect(typeof withArg).toBe('number');
+  });
+});
+
+describe('compat: documented stubs return RNDI-parity values', () => {
+  test('getInstanceId / getInstanceIdSync return "unknown"', async () => {
+    await expect(compat.getInstanceId()).resolves.toBe('unknown');
+    expect(compat.getInstanceIdSync()).toBe('unknown');
+  });
+
+  test('getAppSetId returns the no-dependency RNDI value', async () => {
+    await expect(compat.getAppSetId()).resolves.toEqual({
+      id: 'unknown',
+      scope: -1,
+    });
+  });
+
+  test('getUserAgentSync returns empty placeholder', () => {
+    expect(compat.getUserAgentSync()).toBe('');
+  });
+
+  test('getInstallReferrerSync returns "unknown" placeholder', () => {
+    expect(compat.getInstallReferrerSync()).toBe('unknown');
+  });
+});
+
+describe('compat: power state shape matches core', () => {
+  test('getPowerState resolves with PowerState fields', async () => {
+    const state = await compat.getPowerState();
+    expect(typeof state).toBe('object');
+    expect(typeof state.batteryLevel).toBe('number');
+    expect(['unknown', 'unplugged', 'charging', 'full']).toContain(
+      state.batteryState
+    );
+    expect(typeof state.lowPowerMode).toBe('boolean');
+  });
+});
+
+describe('compat: passthrough async methods resolve to strings', () => {
+  test('getIpAddress / getCarrier / getMacAddress', async () => {
+    await expect(compat.getIpAddress()).resolves.toEqual(expect.any(String));
+    await expect(compat.getCarrier()).resolves.toEqual(expect.any(String));
+    const mac = await compat.getMacAddress();
+    expect(typeof mac).toBe('string');
+    if (Platform.OS === 'ios') {
+      expect(mac).toBe('02:00:00:00:00:00');
+    }
+  });
+
+  // Sync passthroughs must return the same string type as their async
+  // counterparts. IP can change between calls so we only assert its type. The
+  // MAC sync passthrough must equal core (a stable privacy-fixed value).
+  test('sync passthroughs return strings; MAC matches core', () => {
+    expect(typeof compat.getIpAddressSync()).toBe('string');
+    expect(typeof compat.getCarrierSync()).toBe('string');
+    expect(compat.getMacAddressSync()).toBe(DeviceInfoModule.getMacAddressSync());
+  });
+
+  // Regression: async getCarrier must return the SAME carrier as the sync
+  // path. The iOS native getCarrier() async previously returned a hardcoded
+  // '' while getCarrierSync() did the real CTTelephony query, so async callers
+  // silently got an empty string. Both read the same 5s-cached value now.
+  test('async getCarrier agrees with sync carrier', async () => {
+    const asyncCarrier = await compat.getCarrier();
+    expect(typeof asyncCarrier).toBe('string');
+    expect(asyncCarrier).toBe(compat.getCarrierSync());
+  });
+});
+
+describe('compat: default object aggregates named exports', () => {
+  test('default object exposes named functions as methods', async () => {
+    expect(typeof DeviceInfo.getModel).toBe('function');
+    expect(DeviceInfo.getModel()).toBe(compat.getModel());
+    await expect(DeviceInfo.getUniqueId()).resolves.toBe(
+      await compat.getUniqueId()
+    );
+  });
+
+  test('default object and named exports reference the same functions', () => {
+    expect(DeviceInfo.getModel).toBe(compat.getModel);
+    expect(DeviceInfo.getUniqueId).toBe(compat.getUniqueId);
+  });
+
+  test('DeviceInfo named export equals the default export', () => {
+    expect(compat.DeviceInfo).toBe(DeviceInfo);
+  });
+
+  test('default object re-exposes hooks as methods', () => {
+    expect(typeof DeviceInfo.useBatteryLevel).toBe('function');
+    expect(typeof DeviceInfo.useIsHeadphonesConnected).toBe('function');
+    expect(typeof DeviceInfo.useManufacturer).toBe('function');
+  });
+});

--- a/example/showcase/src/__tests__/compat-hooks.harness.tsx
+++ b/example/showcase/src/__tests__/compat-hooks.harness.tsx
@@ -1,0 +1,45 @@
+/**
+ * E2E Tests: RNDI compat layer hooks
+ *
+ * Verifies the compat layer re-exports the full set of `react-native-device-info`
+ * hooks as named functions, so an RNDI codebase that imports hooks from
+ * `react-native-nitro-device-info/compat` resolves every symbol.
+ */
+
+import { describe, test, expect } from 'react-native-harness';
+import * as compat from 'react-native-nitro-device-info/compat';
+
+// The 12 hooks `react-native-device-info` exposes, which the compat layer must
+// provide for a drop-in import to type-check and resolve at runtime.
+const RNDI_HOOK_NAMES = [
+  'useBatteryLevel',
+  'useBatteryLevelIsLow',
+  'usePowerState',
+  'useBrightness',
+  'useIsHeadphonesConnected',
+  'useIsWiredHeadphonesConnected',
+  'useIsBluetoothHeadphonesConnected',
+  'useFirstInstallTime',
+  'useDeviceName',
+  'useHasSystemFeature',
+  'useIsEmulator',
+  'useManufacturer',
+] as const;
+
+describe('compat hooks: every RNDI hook is exported as a function', () => {
+  for (const name of RNDI_HOOK_NAMES) {
+    test(`${name} is exported as a function`, () => {
+      const hook = (compat as Record<string, unknown>)[name];
+      expect(hook).toBeDefined();
+      expect(typeof hook).toBe('function');
+    });
+  }
+});
+
+describe('compat hooks: re-exported core hooks are the same reference', () => {
+  test('useBatteryLevel / usePowerState / useBrightness are functions', () => {
+    expect(typeof compat.useBatteryLevel).toBe('function');
+    expect(typeof compat.usePowerState).toBe('function');
+    expect(typeof compat.useBrightness).toBe('function');
+  });
+});

--- a/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
+++ b/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
@@ -711,9 +711,9 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   /// Get MAC address (hardcoded on iOS 7+ due to privacy restrictions)
   public func getMacAddress() throws -> Promise<String> {
-    return Promise.async {
-      return "02:00:00:00:00:00"
-    }
+    // Immediate value: resolved avoids the Promise.async Task-schedule delay
+    // that can race a pending C++ Promise to destruction.
+    return Promise.resolved(withResult: getMacAddressSync())
   }
 
   /// Get MAC address (hardcoded on iOS 7+ due to privacy restrictions)
@@ -753,12 +753,10 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   /// Get cellular carrier name
   public func getCarrier() throws -> Promise<String> {
-    return Promise.async {
-      if #available(iOS 12.0, *) {
-        return ""
-      }
-      return ""
-    }
+    // Delegate to the sync query (5s cache) so async matches sync and Android's
+    // real carrier name; resolved avoids the Promise.async Task-schedule delay
+    // that can race a pending C++ Promise to destruction.
+    return Promise.resolved(withResult: getCarrierSync())
   }
 
   /// Get carrier name with 5-second cache
@@ -811,9 +809,10 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   /// Check if headphones are connected
   public func isHeadphonesConnected() throws -> Promise<Bool> {
-    return Promise.async {
-      return false
-    }
+    // Delegate to the sync AVAudioSession query so async matches sync (was
+    // hardcoded false); resolved avoids the Promise.async Task-schedule delay
+    // that can race a pending C++ Promise to destruction.
+    return Promise.resolved(withResult: getIsHeadphonesConnected())
   }
 
   /// Check if any headphones are connected
@@ -843,8 +842,12 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   /// Check if location services are enabled
   public func isLocationEnabled() throws -> Promise<Bool> {
-    return Promise.async {
-      return false
+    // Stays on Promise.async (not resolved): CLLocationManager
+    // .locationServicesEnabled() can block and warns when called on the main
+    // thread, so it runs in the Task rather than synchronously on the caller.
+    // The sync logic is reused (was hardcoded false) so async matches sync.
+    return Promise.async { [weak self] in
+      self?.getIsLocationEnabled() ?? false
     }
   }
 

--- a/packages/react-native-nitro-device-info/src/index.ts
+++ b/packages/react-native-nitro-device-info/src/index.ts
@@ -75,8 +75,18 @@ function getNativeInstance(): DeviceInfo {
  * ```
  */
 export const DeviceInfoModule: DeviceInfo = new Proxy({} as DeviceInfo, {
-  get(_target, prop, receiver) {
-    return Reflect.get(getNativeInstance(), prop, receiver);
+  get(_target, prop) {
+    // Read from the native HybridObject WITHOUT forwarding `receiver`. Passing
+    // the Proxy as `receiver` (e.g. `Reflect.get(instance, prop, receiver)`)
+    // would run Nitro's native getters/methods with `this` bound to the Proxy,
+    // whose target is an empty object with no NativeState — every access then
+    // throws "`this` does not have a NativeState". Reading directly off the
+    // instance keeps `this` bound to the real HybridObject. Methods are bound to
+    // the instance for the same reason: an unbound function called later would
+    // lose its `this`.
+    const instance = getNativeInstance();
+    const value = instance[prop as keyof DeviceInfo];
+    return typeof value === 'function' ? value.bind(instance) : value;
   },
   has(_target, prop) {
     return Reflect.has(getNativeInstance(), prop);


### PR DESCRIPTION
## Summary

While adding E2E coverage for the recently merged features (compat layer #111, attestation #113, web fallback #114), the on-device harness surfaced two runtime bugs that the existing jsdom unit tests could not catch because they mock the native module. This PR fixes both and adds E2E tests for the compat layer.

## Bug 1: `DeviceInfoModule` proxy loses NativeState (introduced in #114)

#114 changed `DeviceInfoModule` from a direct `createDeviceInfo()` instance to a lazy `Proxy`:

```ts
get(_target, prop, receiver) {
  return Reflect.get(getNativeInstance(), prop, receiver);
}
```

Passing the `Proxy` as the third `receiver` argument makes `Reflect.get` invoke Nitro's native getters with `this` bound to the Proxy (whose target is an empty `{}`), so every property and method access throws `'this' does not have a NativeState!` on a real device. The jsdom unit tests pass because the native module is mocked.

Fix: read the value directly off the native instance and bind methods to it, instead of forwarding the proxy as the receiver. This affects both iOS and Android, since both go through the same JS proxy.

## Bug 2: iOS `getCarrier()` returns empty string + Nitro promise race

On iOS, `getCarrier()` was `Promise.async { return "" }`, so async callers always got an empty string. The actual carrier lookup lives in `getCarrierSync()` (via `CTTelephonyNetworkInfo`). Android's async `getCarrier()` returns the real carrier name, so the two platforms disagreed. `isHeadphonesConnected()` and `isLocationEnabled()` had the same shape: a hardcoded async value while the sync getter did the real query.

Separately, wrapping an immediate value in `Promise.async` schedules a Swift `Task`. If the JS side abandons the promise (timeout) before that Task runs, the pending C++ `Promise<std::string>` is destroyed and throws `Timeouted: Promise<std::string> was destroyed!`. Under the harness this intermittently wedged the `edge-cases` suite.

Fix:
- `getCarrier`, `getMacAddress`, `isHeadphonesConnected` now delegate to their sync logic and return via `Promise.resolved(withResult:)`, which is resolved synchronously and removes the race window. Async now agrees with sync.
- `isLocationEnabled` stays on `Promise.async` (it calls `CLLocationManager.locationServicesEnabled()`, which can block and warns on the main thread) but now reuses the sync logic instead of returning a hardcoded `false`.

## Tests

Added `compat-core.harness.ts` and `compat-hooks.harness.tsx` in the showcase app. Unlike the mocked unit tests, these verify the compat transforms against real native values (location providers array→map, `getFreeDiskStorage` arg handling, power state shape, aliases, documented stubs, default-object identity, hook exports) and include a regression test asserting async `getCarrier` matches the sync carrier.

## Verification

Run on iOS Simulator (iPhone 17 Pro, 26.2) and Android emulator (API 35). Physical-device harness config and `Podfile.lock` are unchanged.

| Suite | iOS | Android |
|---|---|---|
| showcase (incl. compat) | 7/7 suites, 109 tests | 7/7 suites, 108 tests |
| integrity-demo | 3/3 suites, 13 tests | 3/3 suites, 13 tests |

Unit tests 151/151, typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS device information methods now return accurate device data instead of hardcoded placeholder values.
  * Improved method binding behavior for correct execution context.

* **Tests**
  * Added comprehensive end-to-end test suites validating compat-layer API compatibility with core implementations and ensuring all hook exports are properly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->