### PR TITLE
fix: getHasNotch() incorrectly returns true on iPad

### DIFF
--- a/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
+++ b/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
@@ -418,9 +418,13 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   /// Check if device has a display notch
   public func getHasNotch() -> Bool {
+    guard UIDevice.current.userInterfaceIdiom == .phone else {
+      return false
+    }
+
     if #available(iOS 11.0, *) {
       guard let window = keyWindow else { return false }
-      return window.safeAreaInsets.bottom > 0
+      return window.safeAreaInsets.top > 20
     }
     return false
   }

--- a/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
+++ b/packages/react-native-nitro-device-info/ios/DeviceInfo.swift
@@ -416,7 +416,7 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
   // MARK: - Display & Screen
 
-  /// Check if device has a display notch
+  /// Check if device has a display notch (mutually exclusive with Dynamic Island)
   public func getHasNotch() -> Bool {
     guard UIDevice.current.userInterfaceIdiom == .phone else {
       return false
@@ -424,7 +424,7 @@ class DeviceInfo: HybridDeviceInfoSpec {
 
     if #available(iOS 11.0, *) {
       guard let window = keyWindow else { return false }
-      return window.safeAreaInsets.top > 20
+      return window.safeAreaInsets.top > 20 && !getHasDynamicIsland()
     }
     return false
   }


### PR DESCRIPTION
## Summary
- `getHasNotch()` checked `window.safeAreaInsets.bottom > 0`, which is true on any device with a home indicator (i.e. every notch-less iPad Pro/Air/mini without a Home button), not just notched iPhones
- Added a `userInterfaceIdiom == .phone` guard (matching the existing `getHasDynamicIsland()` pattern) and switched the check to `safeAreaInsets.top`, since a notch is a top safe-area inset, not a bottom one

## Test plan
- [x] Built and ran the showcase example app on an iPad Pro 11-inch (M5) simulator; confirmed `Has Notch` now reports `No`
- [x] Rebuilt with the pre-fix code on the same simulator to confirm the reported `true` behavior reproduces
- [x] `yarn typecheck` passes
- [x] iOS build succeeds (`xcodebuild ... -sdk iphonesimulator`)

Fixes #121

## Test Evidence

### iPhone 17e

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 17e - 2026-07-05 at 19 44 20" src="https://github.com/user-attachments/assets/665d14b5-6bbf-443d-89f0-eb7ce2cbe2f8" />

### iPhone 17 Pro

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-05 at 19 44 21" src="https://github.com/user-attachments/assets/aa40ebd6-4819-4a2d-938b-04e546d01fb5" />

### iPad Pro 11-inch

<img width="1668" height="2420" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - 2026-07-05 at 19 44 18" src="https://github.com/user-attachments/assets/e69435f9-ef4d-4cb6-91b4-83c16071fd6f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notch detection on iPhone devices for more accurate results.
  * The app now avoids reporting a notch on non-phone devices.
  * Updated iOS 11+ logic to use the top safe-area inset and avoid false positives (including Dynamic Island cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->